### PR TITLE
more ergonomic hashmap usage

### DIFF
--- a/src/naive_bayes_tests.rs
+++ b/src/naive_bayes_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::naive_bayes::{self, new_classifier, Message, NaiveBayesClassifier};
+    use crate::naive_bayes::{self, new_classifier, Counts, Message, NaiveBayesClassifier};
     use std::collections::{HashMap, HashSet};
 
     /* fn messages() -> [Message<'static>; 3] {
@@ -60,33 +60,16 @@ mod tests {
         let mut model = new_classifier(0.5);
         model.train(&messages);
 
-        let mut expected_tokens: HashSet<String> = HashSet::new();
-        expected_tokens.insert("spam".to_string());
-        expected_tokens.insert("ham".to_string());
-        expected_tokens.insert("rules".to_string());
-        expected_tokens.insert("hello".to_string());
+        let mut expected_tokens: HashMap<String, Counts> = HashMap::from([
+            ("spam".to_string(), Counts { spam: 1, ham: 0 }),
+            ("rules".to_string(), Counts { spam: 1, ham: 1 }),
+            ("ham".to_string(), Counts { spam: 0, ham: 2 }),
+            ("hello".to_string(), Counts { spam: 0, ham: 1 }),
+        ]);
 
         assert_eq!(model.tokens, expected_tokens);
-        assert_eq!(model.spam_messages, 1);
-        assert_eq!(model.ham_messages, 2);
-        assert_eq!(
-            model.token_spam_counts,
-            HashMap::from([
-                ("spam".to_string(), 1),
-                ("rules".to_string(), 1),
-                ("ham".to_string(), 0),
-                ("hello".to_string(), 0)
-            ])
-        );
-        assert_eq!(
-            model.token_ham_counts,
-            HashMap::from([
-                ("ham".to_string(), 2),
-                ("rules".to_string(), 1),
-                ("hello".to_string(), 1),
-                ("spam".to_string(), 0)
-            ])
-        );
+        assert_eq!(model.totals.spam, 1);
+        assert_eq!(model.totals.ham, 2);
 
         let text = "hello spam";
 


### PR DESCRIPTION
hi! I enjoyed your article on Naive Bayes that was featured in [This Week In Rust #425](https://this-week-in-rust.org/blog/2022/01/12/this-week-in-rust-425/) and since you asked for help with your hashmap usage, I gave it a shot.

The main difference is that I grouped all of the token maps/sets into a single HashMap and used [the Entry API](https://doc.rust-lang.org/stable/std/collections/hash_map/struct.HashMap.html#method.entry) to access values. I highly recommend getting comfortable with Entry, it's magical and evan available for other collections too!

Since all maps are joined up now, there is up to 3x memory savings, and 3x faster lookups by only needing to hash the string once instead of 3 times. This comes with the need to group spam and ham counts in the same value. So I made a struct with explicitly named fields. This also simplified to a single `totals` field rather than one for each message type.

Thank you for writing the article!